### PR TITLE
Add wandb functionality

### DIFF
--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -250,7 +250,7 @@ class TrainArgs(CommonArgs):
     """Number of GPUs to use"""
     master_addr: str = "127.0.0.1"
     """Address of process 0 which each DDP process will connect to"""
-    master_port: str = "8888"
+    master_port: str = "8889"
     """Port of process 0 which each DDP process will connect to"""
 
     # Model arguments
@@ -291,9 +291,9 @@ class TrainArgs(CommonArgs):
     """For norm aggregation, number by which to divide summed up atomic features"""
     knowledge_base_path: str = None 
     """Path to pickled Knowledge Base"""
-    subgraph_size: int = 8
-    """Size of subgraphs to extract when knowledge_graph is True"""
-    min_subgraph_size: int = 1
+    max_subgraph_size: int = 8
+    """Maximum size of subgraphs to extract when knowledge_graph is True"""
+    min_subgraph_size: int = 4
     """Minimum size of subgraphs to extract when knowledge_graph is True"""
     transformer_num_encoder_layers:int = 3
     """Number of layers for transformer encoder of subgraph embeddings"""
@@ -313,6 +313,8 @@ class TrainArgs(CommonArgs):
     """Number of layers in Phi function for Deepset"""
     model_type:Literal['chemprop', 'knowledge_graph'] = 'chemprop'
     """Which type of model to run"""
+    model_name:str = "vanilla_chemprop"
+    """Name of model which describes the model e.g. kg_vanilla_mean = knowledge graph with vanilla mean aggregation"""
 
     # Training arguments
     epochs: int = 30

--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -4,6 +4,7 @@ from tempfile import TemporaryDirectory
 import pickle
 from typing import List, Optional, Tuple
 from typing_extensions import Literal
+from time import time
 
 import torch
 from tap import Tap  # pip install typed-argument-parser (https://github.com/swansonk14/typed-argument-parser)
@@ -339,6 +340,8 @@ class TrainArgs(CommonArgs):
     """Name of wandb project to log to"""
     wandb_gradient_log_frequency: int = 1000
     """Frequency in steps to log gradients to wandb"""
+    batch_id: int = str(int(time()))
+    """All folds and ensembles will be logged with this batch id"""
 
 
     def __init__(self, *args, **kwargs) -> None:

--- a/chemprop/args.py
+++ b/chemprop/args.py
@@ -282,8 +282,6 @@ class TrainArgs(CommonArgs):
     """For norm aggregation, number by which to divide summed up atomic features"""
     knowledge_base_path: str = None 
     """Path to pickled Knowledge Base"""
-    knowledge_graph: bool = False  
-    """Whether to create a knowledge graph model"""
     subgraph_size: int = 8
     """Size of subgraphs to extract when knowledge_graph is True"""
     transformer_num_encoder_layers:int = 3
@@ -298,8 +296,8 @@ class TrainArgs(CommonArgs):
     """Dimension for transformer input vectors"""
     deepset_num_layers:int = 3
     """Number of layers in Phi function for Deepset"""
-    model_name:str = 'chemprop'
-    """Name of model for logging"""
+    model_type:Literal['chemprop', 'knowledge_graph'] = 'chemprop'
+    """Which type of model to run"""
 
     # Training arguments
     epochs: int = 30
@@ -319,6 +317,15 @@ class TrainArgs(CommonArgs):
     """Maximum magnitude of gradient during training."""
     class_balance: bool = False
     """Trains with an equal number of positives and negatives in each batch."""
+
+    # wandb arguments
+    wandb: bool = False
+    """If True log to wandb"""
+    wandb_project: str = "kg-chem"
+    """Name of wandb project to log to"""
+    wandb_gradient_log_frequency: int = 1000
+    """Frequency in steps to log gradients to wandb"""
+
 
     def __init__(self, *args, **kwargs) -> None:
         super(TrainArgs, self).__init__(*args, **kwargs)

--- a/chemprop/train/cross_validate.py
+++ b/chemprop/train/cross_validate.py
@@ -25,6 +25,7 @@ from chemprop.data import get_data, get_task_names, MoleculeDataset, validate_da
 from chemprop.utils import create_logger, makedirs, timeit
 from chemprop.features import set_extra_atom_fdim
 
+
 @timeit(logger_name=TRAIN_LOGGER_NAME)
 def cross_validate(args: TrainArgs,
                    train_func: Callable[[TrainArgs, MoleculeDataset, Logger], Dict[str, List[float]]]
@@ -112,6 +113,7 @@ def cross_validate(args: TrainArgs,
         info(f'Fold {fold_num}')
         args.seed = init_seed + fold_num
         args.save_dir = os.path.join(save_dir, f'fold_{fold_num}')
+        args.fold_num = fold_num
         makedirs(args.save_dir)
         data.reset_features_and_targets()
 

--- a/chemprop/train/cross_validate.py
+++ b/chemprop/train/cross_validate.py
@@ -1,13 +1,15 @@
 import datetime
-from collections import defaultdict
 import csv
-from logging import Logger
 import os
 import sys
-from typing import Callable, Dict, List, Tuple
-
+import wandb
 import numpy as np
 import pandas as pd
+
+from collections import defaultdict
+from logging import Logger
+from typing import Callable, Dict, List, Tuple
+from kg_chem import KnowledgeBase
 
 from .run_training import run_training
 from chemprop.args import TrainArgs
@@ -15,8 +17,6 @@ from chemprop.constants import TEST_SCORES_FILE_NAME, TRAIN_LOGGER_NAME
 from chemprop.data import get_data, get_task_names, MoleculeDataset, validate_dataset_type
 from chemprop.utils import create_logger, makedirs, timeit
 from chemprop.features import set_extra_atom_fdim
-
-from kg_chem import KnowledgeBase
 
 @timeit(logger_name=TRAIN_LOGGER_NAME)
 def cross_validate(args: TrainArgs,
@@ -34,7 +34,9 @@ def cross_validate(args: TrainArgs,
     :return: A tuple containing the mean and standard deviation performance across folds.
     """
     # save_dir needs to be indexed by model name and time
-    args.save_dir = os.path.join(args.save_dir, args.model_name, datetime.datetime.now().strftime("%Y%m%d-%H%M%S"))
+    args.save_dir = (wandb.run.dir 
+                     if args.wandb
+                     else os.path.join(args.save_dir, args.model_name, datetime.datetime.now().strftime("%Y%m%d-%H%M%S")))
     logger = create_logger(name=TRAIN_LOGGER_NAME, save_dir=args.save_dir, quiet=args.quiet)
     if logger is not None:
         debug, info = logger.debug, logger.info

--- a/chemprop/train/cross_validate.py
+++ b/chemprop/train/cross_validate.py
@@ -44,7 +44,7 @@ def cross_validate(args: TrainArgs,
     # save_dir needs to be indexed by model name, time, and name of dataset
     dataset_name = os.path.basename(os.path.normpath(args.data_path))  # file name of dataset
     dataset_name = os.path.splitext(dataset_name)[0]                   # remove extension
-    args.save_dir = wandb.run.dir if args.wandb else os.path.join(
+    args.save_dir = os.path.join(
         args.save_dir, 
         args.model_name, 
         dataset_name, 
@@ -122,13 +122,14 @@ def cross_validate(args: TrainArgs,
         os.environ['MASTER_PORT'] = args.master_port
 
         # args is not picklable so each process will read the args file
-        
-        mp.set_start_method('spawn', force=True)
-        pool = mp.Pool(processes=args.world_size, maxtasksperchild=1)
-        process_outputs = pool.starmap(
-            train_func, 
-            [(rank, args_path, data, knowledge_base, logger) for rank in range(args.world_size)]
-        )
+#         mp.set_start_method('spawn', force=True)
+#         pool = mp.Pool(processes=args.world_size, maxtasksperchild=1)
+#         process_outputs = pool.starmap(
+#             train_func, 
+#             [(rank, args_path, data, knowledge_base, logger) for rank in range(args.world_size)]
+#         )
+# 
+        mp.spawn(train_func, nprocs=args.world_size, args=(args_path, data, knowledge_base, logger))
 
         print("Multiprocessing Successful")
 

--- a/chemprop/train/evaluate.py
+++ b/chemprop/train/evaluate.py
@@ -2,6 +2,8 @@ from collections import defaultdict
 import logging
 from typing import Dict, List
 
+import wandb
+
 from .predict import predict
 from chemprop.data import MoleculeDataLoader, StandardScaler
 from chemprop.models import MoleculeModel
@@ -109,5 +111,10 @@ def evaluate(model: MoleculeModel,
         dataset_type=dataset_type,
         logger=logger
     )
+
+    wandb.log("test_results", results)
+
+    torch.onnx.export(model, None, "model.onnx")
+    wandb.save("model.onnx")
 
     return results

--- a/chemprop/train/evaluate.py
+++ b/chemprop/train/evaluate.py
@@ -112,9 +112,9 @@ def evaluate(model: MoleculeModel,
         logger=logger
     )
 
-    wandb.log("test_results", results)
-
-    torch.onnx.export(model, None, "model.onnx")
-    wandb.save("model.onnx")
+    if logger == "wandb":
+        wandb.log("test_results", results)
+        torch.onnx.export(model, None, "model.onnx")
+        wandb.save("model.onnx")
 
     return results

--- a/chemprop/train/evaluate.py
+++ b/chemprop/train/evaluate.py
@@ -1,8 +1,8 @@
-from collections import defaultdict
-import logging
-from typing import Dict, List
-
 import wandb
+import logging
+
+from collections import defaultdict
+from typing import Dict, List
 
 from .predict import predict
 from chemprop.data import MoleculeDataLoader, StandardScaler

--- a/chemprop/train/run_training.py
+++ b/chemprop/train/run_training.py
@@ -173,7 +173,8 @@ def run_training(args: TrainArgs,
             grad_clip = args.grad_clip,
             class_balance = args.class_balance
         )
-        wandb.init(project=f"chemprop-{model_idx}", config=hyperparams)
+        if logger == "wandb":
+            wandb.init(project=f"chemprop-{model_idx}", config=hyperparams)
 
         # Ensure that model is saved in correct location for evaluation if 0 epochs
         save_checkpoint(os.path.join(save_dir, MODEL_FILE_NAME), model, scaler, features_scaler, args)

--- a/chemprop/train/run_training.py
+++ b/chemprop/train/run_training.py
@@ -2,6 +2,7 @@ from logging import Logger
 import os
 from typing import Dict, List
 
+import wandb
 import numpy as np
 import pandas as pd
 from tensorboardX import SummaryWriter
@@ -20,6 +21,7 @@ from chemprop.nn_utils import param_count
 from chemprop.utils import build_optimizer, build_lr_scheduler, get_loss_func, load_checkpoint,makedirs, \
     save_checkpoint, save_smiles_splits
 
+WANDB_API_KEY="API KEY GOES HERE"
 
 def run_training(args: TrainArgs,
                  data: MoleculeDataset,
@@ -158,6 +160,20 @@ def run_training(args: TrainArgs,
         if args.cuda:
             debug('Moving model to cuda')
         model = model.to(args.device)
+
+
+        hyperparams = dict(
+            seed = args.seed,
+            pytorch_seed = args.pytorch_seed,
+            epochs = args.epochs,
+            warmup_epochs = args.warmup_epochs,
+            init_lr = args.init_lr,
+            max_lr = args.max_lr,
+            final_lr = args.final_lr,
+            grad_clip = args.grad_clip,
+            class_balance = args.class_balance
+        )
+        wandb.init(project=f"chemprop-{model_idx}", config=hyperparams)
 
         # Ensure that model is saved in correct location for evaluation if 0 epochs
         save_checkpoint(os.path.join(save_dir, MODEL_FILE_NAME), model, scaler, features_scaler, args)

--- a/chemprop/train/train.py
+++ b/chemprop/train/train.py
@@ -98,7 +98,7 @@ def train(model: MoleculeModel,
         gnorm = compute_gnorm(model)
 
         # Log to wandb after every batch
-        if args.wandb:
+        if args.rank == 0 and args.wandb:
             log = {"train_loss": batch_loss, "accuracy": acc, "param norm": pnorm, "gradient_norm": gnorm}
             for i, lr in enumerate(lrs):
                 log[f"learning_rate_{i}"] = lr
@@ -106,7 +106,7 @@ def train(model: MoleculeModel,
             wandb.log(log)
 
         # Log and/or add to tensorboard
-        if (n_iter // args.batch_size) % args.log_frequency == 0:
+        if args.rank == 0 and (n_iter // args.batch_size) % args.log_frequency == 0:
             # metrics aggregated for multiple batches
             loss_avg = loss_sum / iter_count
             acc_avg = acc_sum / iter_count

--- a/chemprop/train/train.py
+++ b/chemprop/train/train.py
@@ -34,12 +34,11 @@ def train(model: MoleculeModel,
     :param scheduler: A learning rate scheduler.
     :param args: A :class:`~chemprop.args.TrainArgs` object containing arguments for training the model.
     :param n_iter: The number of iterations (training examples) trained on so far.
-    :param logger: A logger for recording output.
+    :param logger: A logger for recording output. Is the string "wandb" when wandb logging is sought.
     :param writer: A tensorboardX SummaryWriter.
-    :param name: The name of the model being trained, e.g. chemprop-2
     :return: The total number of iterations (training examples) trained on so far.
     """
-    debug = logger.debug if logger is not None else print
+    debug = logger.debug if logger is not None and logger != "wandb" else print
     
     model.train()
     loss_sum = iter_count = 0
@@ -93,7 +92,8 @@ def train(model: MoleculeModel,
 
             lrs_str = ', '.join(f'lr_{i} = {lr:.4e}' for i, lr in enumerate(lrs))
             debug(f'Loss = {loss_avg:.4e}, PNorm = {pnorm:.4f}, GNorm = {gnorm:.4f}, {lrs_str}')
-            wandb.log({"train_loss": loss_avg, "param norm": pnorm, "gradient_norm": gnorm}, step=n_iter)
+            if logger == "wandb":
+                wandb.log({"train_loss": loss_avg, "param norm": pnorm, "gradient_norm": gnorm}, step=n_iter)
 
             if writer is not None:
                 writer.add_scalar('train_loss', loss_avg, n_iter)

--- a/chemprop/utils.py
+++ b/chemprop/utils.py
@@ -112,7 +112,7 @@ def load_checkpoint(rank: int,
     # Build model TODO: abstract away model creation
     if args.model_type == 'chemprop':
         model = MoleculeModel(args)
-    elif args.model_type == 'knowledge_graph'
+    elif args.model_type == 'knowledge_graph':
         model = KGModel(args)
     else:
         raise ValueError(f"Model type {args.model_type} not supported")
@@ -487,6 +487,7 @@ def set_all_seeds(seed):
 
 class ForkedPdb(pdb.Pdb):
     """A Pdb subclass that may be used
+
     from a forked multiprocessing child
 
     """

--- a/chemprop/utils.py
+++ b/chemprop/utils.py
@@ -68,6 +68,7 @@ def save_checkpoint(path: str,
             'stds': features_scaler.stds
         } if features_scaler is not None else None
     }
+
     torch.save(state, path)
 
 
@@ -97,7 +98,13 @@ def load_checkpoint(path: str,
         args.device = device
 
     # Build model TODO: abstract away model creation
-    model = KGModel(args) if args.knowledge_graph else MoleculeModel(args)
+    if args.model_type == 'chemprop':
+        model = MoleculeModel(args)
+    elif args.model_type == 'knowledge_graph'
+        model = KGModel(args)
+    else:
+        raise ValueError(f"Model type {args.model_type} not supported")
+
     if torch.cuda.device_count() > 1:
         model = nn.DataParallel(model)
 


### PR DESCRIPTION
This adds wandb functionality, without messing with the internals too much. Previously, you would pass a Logger object whenever you wanted to do logging. I just made it such that you can pass the string "wandb" as a Logger, and it will use wandb logging for training/testing. Note that the environment variable WANDB_API_KEY still needs to be set.